### PR TITLE
Configure window texture in Room constructor

### DIFF
--- a/Room.java
+++ b/Room.java
@@ -23,6 +23,9 @@ public class Room {
     wallTex.bind(gl);
     wallTex.setTexParameteri(gl, GL3.GL_TEXTURE_WRAP_S, GL3.GL_REPEAT);
     wallTex.setTexParameteri(gl, GL3.GL_TEXTURE_WRAP_T, GL3.GL_REPEAT);
+    windowTex.bind(gl);
+    windowTex.setTexParameteri(gl, GL3.GL_TEXTURE_WRAP_S, GL3.GL_REPEAT);
+    windowTex.setTexParameteri(gl, GL3.GL_TEXTURE_WRAP_T, GL3.GL_REPEAT);
 
     parts = new ArrayList<>();
     parts.add(makeFloor(gl));


### PR DESCRIPTION
## Summary
- Bind the window texture and set its wrapping mode so the Room class fully supports a third texture for windows.

## Testing
- `javac Room.java` *(fails: cannot find symbol: Texture/GL3 and missing JOGL packages)*

------
https://chatgpt.com/codex/tasks/task_e_68951674fc7483259838264860a17507