### PR TITLE
Add legacy Room constructor to match previous signature

### DIFF
--- a/Room.java
+++ b/Room.java
@@ -13,6 +13,15 @@ public class Room {
   private Texture floorTex, wallTex, windowTex;
   private float size = 16f;
 
+  /**
+   * Legacy constructor that assumes the wall texture is also used for the window.
+   * This allows older code which passed only floor and wall textures to continue
+   * compiling after the introduction of a dedicated window texture.
+   */
+  public Room(GL3 gl, Camera c, Light[] l, Texture floorTex, Texture wallTex) {
+    this(gl, c, l, floorTex, wallTex, wallTex);
+  }
+
   public Room(GL3 gl, Camera c, Light[] l, Texture floorTex, Texture wallTex, Texture windowTex) {
     camera = c;
     lights = l;


### PR DESCRIPTION
## Summary
- add a compatibility constructor for `Room` that forwards to the new three-texture version so older code without a window texture still compiles

## Testing
- `javac Room.java` *(fails: cannot find symbol GL3)*

------
https://chatgpt.com/codex/tasks/task_e_68951e647b5883258377a25d9f5e9d4b