### PR TITLE
Scale room size to match noticeboard

### DIFF
--- a/Room.java
+++ b/Room.java
@@ -12,7 +12,8 @@ public class Room {
   private Light[] lights;
   private Texture floorTex, wallTex, windowTex;
   private Texture noticeboardTex, poster1Tex, poster2Tex, poster3Tex, poster3Specular;
-  private float size = 16f;
+  // Adjusted room size to better align with noticeboard dimensions
+  private float size = 8f;
 
   /**
    * Legacy constructor that assumes the wall texture is also used for the window.


### PR DESCRIPTION
## Summary
- Halve overall room dimensions to better match noticeboard scale

## Testing
- `javac Room.java` *(fails: package com.jogamp.opengl.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68952620a05c83259a63b846e8f843f5