### PR TITLE
Safeguard table rendering

### DIFF
--- a/Room.java
+++ b/Room.java
@@ -228,7 +228,9 @@ public class Room {
     for (ModelMultipleLights m : parts) {
       m.render(gl);
     }
-    table.render(gl);
+    if (table != null) {
+      table.render(gl);
+    }
   }
 
   public void dispose(GL3 gl) {
@@ -240,6 +242,8 @@ public class Room {
     poster2Tex.destroy(gl);
     poster3Tex.destroy(gl);
     poster3Specular.destroy(gl);
-    table.dispose(gl);
+    if (table != null) {
+      table.dispose(gl);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Avoid potential null pointer when rendering the wooden table
- Clean up table resources only when the table was successfully created

## Testing
- `javac Room.java Table.java` *(fails: package com.jogamp.opengl.util.texture.spi does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68952af59aa88325a7d2eb8c0946dda0